### PR TITLE
Add route and certificate entry for monitor.isaacphysics.org

### DIFF
--- a/generate-certs.sh
+++ b/generate-certs.sh
@@ -15,6 +15,7 @@ labs.isaacphysics.org,\
 tickets.isaacphysics.org,\
 editor.isaacphysics.org,\
 cdn.isaacphysics.org,\
+monitor.isaacphysics.org,\
 \
 isaacchemistry.org,\
 www.isaacchemistry.org,\

--- a/nginx.conf
+++ b/nginx.conf
@@ -339,7 +339,7 @@ http {
 
         include proxy-set-headers.conf;
 
-        set $grafana grafana:3000
+        set $grafana grafana:3000;
 
         location / {
             allow 128.232.0.0/16;

--- a/nginx.conf
+++ b/nginx.conf
@@ -332,6 +332,27 @@ http {
     }
 
 
+    # ISAAC MONITOR
+    server {
+        listen       443 ssl;
+        server_name  monitor.isaacphysics.org;
+
+        include proxy-set-headers.conf;
+
+        set $grafana grafana:3000
+
+        location / {
+            allow 128.232.0.0/16;
+            allow 131.111.0.0/16;
+            allow 172.16.0.0/12;
+            allow 10.0.0.0/8;
+            deny all;
+
+            proxy_pass http://$grafana;
+        }
+    }
+
+
     # OWNCLOUD
     server {
         listen 443 ssl;


### PR DESCRIPTION
Router restricts access to trusted IPs.
Grafana then does its own account management.