### PR TITLE
Add temp marker service to Ada

### DIFF
--- a/conf/servers-adacomputerscience.conf
+++ b/conf/servers-adacomputerscience.conf
@@ -230,6 +230,28 @@ server {
 }
 
 
+# ADA MARKER
+server {
+    listen 443 ssl http2;
+    server_name marker.adacomputerscience.org;
+
+    # Load only the base headers, we want to allow this to be framed:
+    include conf/headers-base.conf;
+    include conf/headers-proxy.conf;
+
+    location / {
+        # Enable compression of static assets:
+        gzip on;
+
+        set $marker ada-marker-app:5000;
+        proxy_pass http://$marker;
+    }
+
+    include conf/location-ada-cs-errors.conf;
+    include conf/location-robots-txt-no-robots.conf;
+}
+
+
 # ADA TICKETS
 server {
     listen 443 ssl http2;

--- a/generate-certs.sh
+++ b/generate-certs.sh
@@ -20,6 +20,8 @@ ada-cs.org,\
 \
 code-editor.ada-cs.org,\
 \
+marker.adacomputerscience.org, \
+\
 cdn.isaacphysics.org,\
 cdn.adacomputerscience.org,\
 cdn.isaacscience.org,\


### PR DESCRIPTION
Add configuration for the temporary marker service for Ada.
The config is largely copied from the Ada Code Editor config, so does not currently have a CSP defined in the headers.